### PR TITLE
Read region endpoint from AmazonInitializer.

### DIFF
--- a/CognitoSyncProject/Assets/AWSUnitySDK/AWSCore/Amazon.SecurityToken/AmazonSecurityTokenServiceConfig.cs
+++ b/CognitoSyncProject/Assets/AWSUnitySDK/AWSCore/Amazon.SecurityToken/AmazonSecurityTokenServiceConfig.cs
@@ -13,6 +13,7 @@
 using System;
 
 using Amazon.Runtime;
+using Amazon.Unity;
 
 
 namespace Amazon.SecurityToken
@@ -29,7 +30,7 @@ namespace Amazon.SecurityToken
         {
             this.AuthenticationServiceName = "sts";
             if (this.RegionEndpoint == null)
-                this.RegionEndpoint = RegionEndpoint.USEast1;
+				this.RegionEndpoint = AmazonInitializer.CognitoRegionEndpoint;
         }
 
         /// <summary>

--- a/CognitoSyncProject/Assets/DemoScene/SyncCharacterSelection/SaveManager.cs
+++ b/CognitoSyncProject/Assets/DemoScene/SyncCharacterSelection/SaveManager.cs
@@ -26,6 +26,9 @@ using Amazon.Common;
 /// Contains the Cognito Sync related classes.
 /// Reads and stores a CharacterList to a Cognito Sync dataset.
 /// </summary>
+using Amazon.Unity;
+
+
 public class SaveManager : MonoBehaviour
 {
 
@@ -80,7 +83,7 @@ public class SaveManager : MonoBehaviour
         // DefaultCognitoSyncManager is a high level CognitoSync Client which handles all Sync operations at a Dataset level.
         // Additionally, it also provides local storage of the Datasets which can be later Synchronized with the cloud(CognitoSync service)
         // This feature allows the user to continue working w/o internet access and sync with CognitoSync whenever possible
-        syncManager = new DefaultCognitoSyncManager (credentials, new AmazonCognitoSyncConfig { RegionEndpoint = RegionEndpoint.USEast1 });
+		syncManager = new DefaultCognitoSyncManager (credentials, new AmazonCognitoSyncConfig { RegionEndpoint = AmazonInitializer.CognitoRegionEndpoint });
 
         initializationPending = true;
     }


### PR DESCRIPTION
The example project failed for me because all our stuff is set up in EU West 1 which, along with all the other necessary settings, is set up in the AWSPrefab (AmazonInitializer script).  This wasn't being read in in by SaveManager, nor AmazonSecurityTokenServiceConfig, instead they incorrectly just defaulted to US East 1.  With these small configuration changes, all now works as expected (perfectly ;) ).
