### PR TITLE
add sns: to IAM policy example.

### DIFF
--- a/Chess Game Example Project/README.md
+++ b/Chess Game Example Project/README.md
@@ -237,8 +237,8 @@ You will be prompted to choose roles for identities in your pool. Create a role 
                 "sns:CreatePlatformEndpoint"
             ],
             "Resource": [
-                "arn:aws:<RESOURCE REGION>:*:app/APNS_SANDBOX/ChessGame",
-                "arn:aws:<RESOURCE REGION>:*:app/GCM/ChessGame"
+                "arn:aws:sns:<RESOURCE REGION>:*:app/APNS_SANDBOX/ChessGame",
+                "arn:aws:sns:<RESOURCE REGION>:*:app/GCM/ChessGame"
             ]
         },
         {


### PR DESCRIPTION
The IAM policy failed to create due to invalid arn's. Adding "sns:" fixed the issue.
